### PR TITLE
Fixing encoding for special characters in URL and Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Check out a preview here: [http://devpodcasts.app](http://devpodcasts.app)
 Dev:
 ```npm install && gatsby develop```
 
+Then open a browser to:
+http://localhost:8000 
+
 Publishing:
 ```gatsby build```
 

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -93,10 +93,10 @@ export default ({ data }) => {
               <li key={tagCount.tag} className='tag'>
                 {/* TODO Actually search via tag, which also fixes the "none" */}
                 <a
-                  href={`https://qit.cloud/search/"${tagCount.tag.replace(
+                  href={`https://qit.cloud/search/${encodeURIComponent(tagCount.tag.replace(
                     `-`,
                     ' '
-                  )}"`}
+                  ))}`}
                 >
                   {tagCount.tag} x {tagCount.count}
                 </a>


### PR DESCRIPTION
Keywords that weren't being encoded properly were failing retrieving search results in QIT - things like C# were failing.